### PR TITLE
feat: 관리자 블로그 통계 및 통계 재집계 기능 구현(#32)

### DIFF
--- a/src/components/admin/AdminBlogStatsChart.tsx
+++ b/src/components/admin/AdminBlogStatsChart.tsx
@@ -1,0 +1,29 @@
+import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { NormalizedBlogStatPoint } from "./types";
+
+type Props = {
+  data: NormalizedBlogStatPoint[];
+};
+
+export function AdminBlogStatsChart({ data }: Props) {
+  return (
+    <div className="rounded-lg border border-border bg-background/60 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <p className="text-sm font-semibold text-foreground">포스트 수 추이</p>
+        <p className="text-xs text-muted-foreground">기간별 발행 포스트 수</p>
+      </div>
+      <div className="h-[280px] w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+            <XAxis dataKey="label" tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }} />
+            <YAxis tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }} tickFormatter={(v) => v.toLocaleString()} />
+            <Tooltip formatter={(value: number) => value.toLocaleString()} contentStyle={{ borderRadius: 8, borderColor: "hsl(var(--border))" }} />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            <Line type="monotone" dataKey="postCount" name="포스트 수" stroke="hsl(var(--primary))" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/AdminBlogStatsControls.tsx
+++ b/src/components/admin/AdminBlogStatsControls.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Granularity, DailyRange, WeeklyPeriod } from "./types";
-import { granularityOptions } from "./userStatsUtils";
+import { granularityOptions } from "./blogStatsUtils";
 import { RefreshCw, Loader2 } from "lucide-react";
 
 type Props = {
@@ -18,7 +18,7 @@ type Props = {
   isReaggregating?: boolean;
 };
 
-export function AdminUserStatsControls({
+export function AdminBlogStatsControls({
   granularity,
   dailyRange,
   weeklyPeriod,

--- a/src/components/admin/AdminBlogStatsSection.tsx
+++ b/src/components/admin/AdminBlogStatsSection.tsx
@@ -1,100 +1,42 @@
-import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, BarChart3, Loader2 } from "lucide-react";
-import { AxiosError } from "axios";
-import { statisticsService } from "@/services/statisticsService";
-import { DailyRange, Granularity, NormalizedBlogStatPoint, WeeklyPeriod } from "./types";
 import { AdminBlogStatsControls } from "./AdminBlogStatsControls";
 import { AdminBlogStatsSummary } from "./AdminBlogStatsSummary";
 import { AdminBlogStatsChart } from "./AdminBlogStatsChart";
 import { AdminBlogStatsTable } from "./AdminBlogStatsTable";
 import { defaultDailyRange, defaultMonthlyYear, defaultWeeklyPeriod, normalizeBlogStats } from "./blogStatsUtils";
+import { useStatistics } from "@/hooks/useStatistics";
 
 type AdminBlogStatsSectionProps = {
   active: boolean;
 };
 
 export function AdminBlogStatsSection({ active }: AdminBlogStatsSectionProps) {
-  const [granularity, setGranularity] = useState<Granularity>("daily");
-  const [dailyRange, setDailyRange] = useState<DailyRange>(defaultDailyRange());
-  const [weeklyPeriod, setWeeklyPeriod] = useState<WeeklyPeriod>(defaultWeeklyPeriod());
-  const [monthlyYear, setMonthlyYear] = useState<number>(defaultMonthlyYear());
-  const [data, setData] = useState<NormalizedBlogStatPoint[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isReaggregating, setIsReaggregating] = useState(false);
-
-  const fetchStats = async () => {
-    try {
-      setLoading(true);
-      const raw =
-        granularity === "daily"
-          ? await statisticsService.getBlogStats({
-              granularity,
-              startDate: dailyRange.start,
-              endDate: dailyRange.end,
-            })
-          : granularity === "weekly"
-          ? await statisticsService.getBlogStats({
-              granularity,
-              year: weeklyPeriod.year,
-              month: weeklyPeriod.month,
-            })
-          : await statisticsService.getBlogStats({
-              granularity,
-              year: monthlyYear,
-            });
-      setData(normalizeBlogStats(granularity, raw));
-      setError(null);
-    } catch (err) {
-      const msg = err instanceof AxiosError
-        ? err.response?.data?.message || err.message
-        : err instanceof Error
-        ? err.message
-        : "블로그 통계를 불러오지 못했습니다.";
-      setError(msg);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (!active) return;
-    fetchStats();
-  }, [active, granularity, dailyRange.start, dailyRange.end, weeklyPeriod.year, weeklyPeriod.month, monthlyYear]);
-
-  const handleReaggregate = async () => {
-    if (granularity !== "daily") {
-      alert("일별 조회 모드에서만 재집계가 가능합니다.");
-      return;
-    }
-
-    const confirmed = confirm(
-      `${dailyRange.start} ~ ${dailyRange.end} 기간의 통계를 재집계하시겠습니까?\n기존 데이터는 덮어씌워집니다.`
-    );
-
-    if (!confirmed) return;
-
-    try {
-      setIsReaggregating(true);
-      await statisticsService.reaggregateStats(dailyRange.start, dailyRange.end);
-
-      // 재집계 성공 후 통계 다시 불러오기
-      await fetchStats();
-
-      alert("통계 재집계가 완료되었습니다.");
-    } catch (err) {
-      const msg = err instanceof AxiosError
-        ? err.response?.data?.message || err.message
-        : "재집계에 실패했습니다.";
-      alert(msg);
-    } finally {
-      setIsReaggregating(false);
-    }
-  };
-
-  const latest = useMemo(() => data[data.length - 1], [data]);
+  const {
+    granularity,
+    setGranularity,
+    dailyRange,
+    setDailyRange,
+    weeklyPeriod,
+    setWeeklyPeriod,
+    monthlyYear,
+    setMonthlyYear,
+    data,
+    loading,
+    error,
+    isReaggregating,
+    handleReaggregate,
+    latest,
+  } = useStatistics({
+    active,
+    statType: "blog",
+    normalizeStats: normalizeBlogStats,
+    defaultDailyRange,
+    defaultWeeklyPeriod,
+    defaultMonthlyYear,
+    errorMessage: "블로그 통계를 불러오지 못했습니다.",
+  });
 
   return (
     <Card className="card-shadow overflow-hidden">

--- a/src/components/admin/AdminBlogStatsSection.tsx
+++ b/src/components/admin/AdminBlogStatsSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, BarChart3, Loader2 } from "lucide-react";
+import { AxiosError } from "axios";
 import { statisticsService } from "@/services/statisticsService";
 import { DailyRange, Granularity, NormalizedBlogStatPoint, WeeklyPeriod } from "./types";
 import { AdminBlogStatsControls } from "./AdminBlogStatsControls";
@@ -47,10 +48,11 @@ export function AdminBlogStatsSection({ active }: AdminBlogStatsSectionProps) {
       setData(normalizeBlogStats(granularity, raw));
       setError(null);
     } catch (err) {
-      const msg =
-        (err as any)?.response?.data?.message ||
-        (err as Error)?.message ||
-        "블로그 통계를 불러오지 못했습니다.";
+      const msg = err instanceof AxiosError
+        ? err.response?.data?.message || err.message
+        : err instanceof Error
+        ? err.message
+        : "블로그 통계를 불러오지 못했습니다.";
       setError(msg);
     } finally {
       setLoading(false);
@@ -83,7 +85,9 @@ export function AdminBlogStatsSection({ active }: AdminBlogStatsSectionProps) {
 
       alert("통계 재집계가 완료되었습니다.");
     } catch (err) {
-      const msg = (err as any)?.response?.data?.message || "재집계에 실패했습니다.";
+      const msg = err instanceof AxiosError
+        ? err.response?.data?.message || err.message
+        : "재집계에 실패했습니다.";
       alert(msg);
     } finally {
       setIsReaggregating(false);

--- a/src/components/admin/AdminBlogStatsSection.tsx
+++ b/src/components/admin/AdminBlogStatsSection.tsx
@@ -3,23 +3,23 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, BarChart3, Loader2 } from "lucide-react";
 import { statisticsService } from "@/services/statisticsService";
-import { DailyRange, Granularity, NormalizedUserStatPoint, WeeklyPeriod } from "./types";
-import { AdminUserStatsControls } from "./AdminUserStatsControls";
-import { AdminUserStatsSummary } from "./AdminUserStatsSummary";
-import { AdminUserStatsChart } from "./AdminUserStatsChart";
-import { AdminUserStatsTable } from "./AdminUserStatsTable";
-import { defaultDailyRange, defaultMonthlyYear, defaultWeeklyPeriod, normalizeUserStats } from "./userStatsUtils";
+import { DailyRange, Granularity, NormalizedBlogStatPoint, WeeklyPeriod } from "./types";
+import { AdminBlogStatsControls } from "./AdminBlogStatsControls";
+import { AdminBlogStatsSummary } from "./AdminBlogStatsSummary";
+import { AdminBlogStatsChart } from "./AdminBlogStatsChart";
+import { AdminBlogStatsTable } from "./AdminBlogStatsTable";
+import { defaultDailyRange, defaultMonthlyYear, defaultWeeklyPeriod, normalizeBlogStats } from "./blogStatsUtils";
 
-type AdminUserStatsSectionProps = {
+type AdminBlogStatsSectionProps = {
   active: boolean;
 };
 
-export function AdminUserStatsSection({ active }: AdminUserStatsSectionProps) {
+export function AdminBlogStatsSection({ active }: AdminBlogStatsSectionProps) {
   const [granularity, setGranularity] = useState<Granularity>("daily");
   const [dailyRange, setDailyRange] = useState<DailyRange>(defaultDailyRange());
   const [weeklyPeriod, setWeeklyPeriod] = useState<WeeklyPeriod>(defaultWeeklyPeriod());
   const [monthlyYear, setMonthlyYear] = useState<number>(defaultMonthlyYear());
-  const [data, setData] = useState<NormalizedUserStatPoint[]>([]);
+  const [data, setData] = useState<NormalizedBlogStatPoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isReaggregating, setIsReaggregating] = useState(false);
@@ -29,28 +29,28 @@ export function AdminUserStatsSection({ active }: AdminUserStatsSectionProps) {
       setLoading(true);
       const raw =
         granularity === "daily"
-          ? await statisticsService.getUserStats({
+          ? await statisticsService.getBlogStats({
               granularity,
               startDate: dailyRange.start,
               endDate: dailyRange.end,
             })
           : granularity === "weekly"
-          ? await statisticsService.getUserStats({
+          ? await statisticsService.getBlogStats({
               granularity,
               year: weeklyPeriod.year,
               month: weeklyPeriod.month,
             })
-          : await statisticsService.getUserStats({
+          : await statisticsService.getBlogStats({
               granularity,
               year: monthlyYear,
             });
-      setData(normalizeUserStats(granularity, raw));
+      setData(normalizeBlogStats(granularity, raw));
       setError(null);
     } catch (err) {
       const msg =
         (err as any)?.response?.data?.message ||
         (err as Error)?.message ||
-        "사용자 통계를 불러오지 못했습니다.";
+        "블로그 통계를 불러오지 못했습니다.";
       setError(msg);
     } finally {
       setLoading(false);
@@ -97,13 +97,13 @@ export function AdminUserStatsSection({ active }: AdminUserStatsSectionProps) {
       <CardHeader className="bg-muted/40 flex flex-col gap-2">
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <BarChart3 className="h-4 w-4" />
-          <span>사용자 통계</span>
+          <span>블로그 통계</span>
         </div>
-        <CardTitle className="text-xl">가입/활성 사용자 추이</CardTitle>
-        <p className="text-sm text-muted-foreground">기간과 단위를 선택해 사용자 추이를 확인하세요.</p>
+        <CardTitle className="text-xl">포스트 발행 추이</CardTitle>
+        <p className="text-sm text-muted-foreground">기간과 단위를 선택해 블로그 포스트 추이를 확인하세요.</p>
       </CardHeader>
       <CardContent className="space-y-4">
-        <AdminUserStatsControls
+        <AdminBlogStatsControls
           granularity={granularity}
           dailyRange={dailyRange}
           weeklyPeriod={weeklyPeriod}
@@ -143,7 +143,7 @@ export function AdminUserStatsSection({ active }: AdminUserStatsSectionProps) {
           </div>
         ) : (
           <>
-            <AdminUserStatsSummary
+            <AdminBlogStatsSummary
               latest={latest}
               granularity={granularity}
               dailyRange={dailyRange}
@@ -151,9 +151,9 @@ export function AdminUserStatsSection({ active }: AdminUserStatsSectionProps) {
               monthlyYear={monthlyYear}
             />
 
-            <AdminUserStatsChart data={data} />
+            <AdminBlogStatsChart data={data} />
 
-            <AdminUserStatsTable data={data} />
+            <AdminBlogStatsTable data={data} />
           </>
         )}
       </CardContent>

--- a/src/components/admin/AdminBlogStatsSummary.tsx
+++ b/src/components/admin/AdminBlogStatsSummary.tsx
@@ -1,0 +1,51 @@
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { Granularity, NormalizedBlogStatPoint, DailyRange, WeeklyPeriod } from "./types";
+import { formatRate, granularityOptions } from "./blogStatsUtils";
+
+type Props = {
+  latest?: NormalizedBlogStatPoint;
+  granularity: Granularity;
+  dailyRange: DailyRange;
+  weeklyPeriod: WeeklyPeriod;
+  monthlyYear: number;
+};
+
+export function AdminBlogStatsSummary({ latest, granularity, dailyRange, weeklyPeriod, monthlyYear }: Props) {
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      <Card className="border border-border/80">
+        <CardHeader className="py-3">
+          <p className="text-xs text-muted-foreground">총 포스트 수</p>
+          <CardTitle className="text-xl">{latest ? latest.postCount.toLocaleString() : "-"}</CardTitle>
+          <p className="text-xs text-muted-foreground">전 기간 대비 {formatRate(latest?.postGrowthRate ?? 0)}</p>
+        </CardHeader>
+      </Card>
+      <Card className="border border-border/80">
+        <CardHeader className="py-3">
+          <p className="text-xs text-muted-foreground">최근 기간</p>
+          <CardTitle className="text-xl">{latest?.label ?? "-"}</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            {latest && latest.postGrowthRate >= 0 ? "증가 추세" : "감소 추세"}
+          </p>
+        </CardHeader>
+      </Card>
+      <Card className="border border-border/80">
+        <CardHeader className="py-3">
+          <p className="text-xs text-muted-foreground">조회 기간</p>
+          <CardTitle className="text-xl">
+            {granularity === "daily" && (
+              <>
+                {dailyRange.start} ~ {dailyRange.end}
+              </>
+            )}
+            {granularity === "weekly" && `${weeklyPeriod.year}년 ${weeklyPeriod.month}월`}
+            {granularity === "monthly" && `${monthlyYear}년`}
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">
+            단위: {granularityOptions.find((g) => g.value === granularity)?.label}
+          </p>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/admin/AdminBlogStatsTable.tsx
+++ b/src/components/admin/AdminBlogStatsTable.tsx
@@ -1,0 +1,37 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { NormalizedBlogStatPoint } from "./types";
+import { formatRate } from "./blogStatsUtils";
+
+type Props = {
+  data: NormalizedBlogStatPoint[];
+};
+
+export function AdminBlogStatsTable({ data }: Props) {
+  return (
+    <div className="rounded-lg border border-border overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-secondary/50">
+            <TableHead className="w-48 text-center">기간</TableHead>
+            <TableHead className="w-32 text-center">포스트 수</TableHead>
+            <TableHead className="w-32 text-center">전 기간 대비</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((row) => (
+            <TableRow key={row.label} className="hover:bg-muted/50">
+              <TableCell className="text-center text-muted-foreground">{row.label}</TableCell>
+              <TableCell className="text-center font-semibold text-foreground">{row.postCount.toLocaleString()}</TableCell>
+              <TableCell className="text-center">
+                <Badge variant={row.postGrowthRate >= 0 ? "success" : "destructive"} className="min-w-[80px] justify-center">
+                  {formatRate(row.postGrowthRate)}
+                </Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/admin/AdminMainContent.tsx
+++ b/src/components/admin/AdminMainContent.tsx
@@ -7,6 +7,7 @@ import { AdminWorkSection } from "./AdminWorkSection";
 import { Settings2 } from "lucide-react";
 import { AdminUserStatsSection } from "./AdminUserStatsSection";
 import { AdminCommonCodeSection } from "./AdminCommonCodeSection";
+import { AdminBlogStatsSection } from "./AdminBlogStatsSection";
 
 type AdminMainContentProps = {
   section: AdminSection;
@@ -58,6 +59,10 @@ export function AdminMainContent({ section, onSectionChange, userFilter, workflo
 
   if (section === "stats") {
     return <AdminUserStatsSection active />;
+  }
+
+  if (section === "blog") {
+    return <AdminBlogStatsSection active />;
   }
 
   if (section === "code") {

--- a/src/components/admin/AdminUserStatsSection.tsx
+++ b/src/components/admin/AdminUserStatsSection.tsx
@@ -1,100 +1,42 @@
-import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, BarChart3, Loader2 } from "lucide-react";
-import { AxiosError } from "axios";
-import { statisticsService } from "@/services/statisticsService";
-import { DailyRange, Granularity, NormalizedUserStatPoint, WeeklyPeriod } from "./types";
 import { AdminUserStatsControls } from "./AdminUserStatsControls";
 import { AdminUserStatsSummary } from "./AdminUserStatsSummary";
 import { AdminUserStatsChart } from "./AdminUserStatsChart";
 import { AdminUserStatsTable } from "./AdminUserStatsTable";
 import { defaultDailyRange, defaultMonthlyYear, defaultWeeklyPeriod, normalizeUserStats } from "./userStatsUtils";
+import { useStatistics } from "@/hooks/useStatistics";
 
 type AdminUserStatsSectionProps = {
   active: boolean;
 };
 
 export function AdminUserStatsSection({ active }: AdminUserStatsSectionProps) {
-  const [granularity, setGranularity] = useState<Granularity>("daily");
-  const [dailyRange, setDailyRange] = useState<DailyRange>(defaultDailyRange());
-  const [weeklyPeriod, setWeeklyPeriod] = useState<WeeklyPeriod>(defaultWeeklyPeriod());
-  const [monthlyYear, setMonthlyYear] = useState<number>(defaultMonthlyYear());
-  const [data, setData] = useState<NormalizedUserStatPoint[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isReaggregating, setIsReaggregating] = useState(false);
-
-  const fetchStats = async () => {
-    try {
-      setLoading(true);
-      const raw =
-        granularity === "daily"
-          ? await statisticsService.getUserStats({
-              granularity,
-              startDate: dailyRange.start,
-              endDate: dailyRange.end,
-            })
-          : granularity === "weekly"
-          ? await statisticsService.getUserStats({
-              granularity,
-              year: weeklyPeriod.year,
-              month: weeklyPeriod.month,
-            })
-          : await statisticsService.getUserStats({
-              granularity,
-              year: monthlyYear,
-            });
-      setData(normalizeUserStats(granularity, raw));
-      setError(null);
-    } catch (err) {
-      const msg = err instanceof AxiosError
-        ? err.response?.data?.message || err.message
-        : err instanceof Error
-        ? err.message
-        : "사용자 통계를 불러오지 못했습니다.";
-      setError(msg);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (!active) return;
-    fetchStats();
-  }, [active, granularity, dailyRange.start, dailyRange.end, weeklyPeriod.year, weeklyPeriod.month, monthlyYear]);
-
-  const handleReaggregate = async () => {
-    if (granularity !== "daily") {
-      alert("일별 조회 모드에서만 재집계가 가능합니다.");
-      return;
-    }
-
-    const confirmed = confirm(
-      `${dailyRange.start} ~ ${dailyRange.end} 기간의 통계를 재집계하시겠습니까?\n기존 데이터는 덮어씌워집니다.`
-    );
-
-    if (!confirmed) return;
-
-    try {
-      setIsReaggregating(true);
-      await statisticsService.reaggregateStats(dailyRange.start, dailyRange.end);
-
-      // 재집계 성공 후 통계 다시 불러오기
-      await fetchStats();
-
-      alert("통계 재집계가 완료되었습니다.");
-    } catch (err) {
-      const msg = err instanceof AxiosError
-        ? err.response?.data?.message || err.message
-        : "재집계에 실패했습니다.";
-      alert(msg);
-    } finally {
-      setIsReaggregating(false);
-    }
-  };
-
-  const latest = useMemo(() => data[data.length - 1], [data]);
+  const {
+    granularity,
+    setGranularity,
+    dailyRange,
+    setDailyRange,
+    weeklyPeriod,
+    setWeeklyPeriod,
+    monthlyYear,
+    setMonthlyYear,
+    data,
+    loading,
+    error,
+    isReaggregating,
+    handleReaggregate,
+    latest,
+  } = useStatistics({
+    active,
+    statType: "user",
+    normalizeStats: normalizeUserStats,
+    defaultDailyRange,
+    defaultWeeklyPeriod,
+    defaultMonthlyYear,
+    errorMessage: "사용자 통계를 불러오지 못했습니다.",
+  });
 
   return (
     <Card className="card-shadow overflow-hidden">

--- a/src/components/admin/AdminUserStatsSection.tsx
+++ b/src/components/admin/AdminUserStatsSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle, BarChart3, Loader2 } from "lucide-react";
+import { AxiosError } from "axios";
 import { statisticsService } from "@/services/statisticsService";
 import { DailyRange, Granularity, NormalizedUserStatPoint, WeeklyPeriod } from "./types";
 import { AdminUserStatsControls } from "./AdminUserStatsControls";
@@ -47,10 +48,11 @@ export function AdminUserStatsSection({ active }: AdminUserStatsSectionProps) {
       setData(normalizeUserStats(granularity, raw));
       setError(null);
     } catch (err) {
-      const msg =
-        (err as any)?.response?.data?.message ||
-        (err as Error)?.message ||
-        "사용자 통계를 불러오지 못했습니다.";
+      const msg = err instanceof AxiosError
+        ? err.response?.data?.message || err.message
+        : err instanceof Error
+        ? err.message
+        : "사용자 통계를 불러오지 못했습니다.";
       setError(msg);
     } finally {
       setLoading(false);
@@ -83,7 +85,9 @@ export function AdminUserStatsSection({ active }: AdminUserStatsSectionProps) {
 
       alert("통계 재집계가 완료되었습니다.");
     } catch (err) {
-      const msg = (err as any)?.response?.data?.message || "재집계에 실패했습니다.";
+      const msg = err instanceof AxiosError
+        ? err.response?.data?.message || err.message
+        : "재집계에 실패했습니다.";
       alert(msg);
     } finally {
       setIsReaggregating(false);

--- a/src/components/admin/blogStatsUtils.ts
+++ b/src/components/admin/blogStatsUtils.ts
@@ -1,0 +1,71 @@
+import { Granularity, NormalizedBlogStatPoint, BlogStatPoint } from "./types";
+
+export const granularityOptions: { value: Granularity; label: string }[] = [
+  { value: "daily", label: "일별" },
+  { value: "weekly", label: "주별" },
+  { value: "monthly", label: "월별" },
+];
+
+export const formatRate = (value: number) => `${(value ?? 0).toFixed(1)}%`;
+
+export const toDateInputString = (date: Date) => date.toISOString().slice(0, 10);
+
+export const defaultDailyRange = () => {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(end.getDate() - 30);
+  return { start: toDateInputString(start), end: toDateInputString(end) };
+};
+
+export const defaultWeeklyPeriod = () => {
+  const now = new Date();
+  return { year: now.getFullYear(), month: now.getMonth() + 1 };
+};
+
+export const defaultMonthlyYear = () => new Date().getFullYear();
+
+export const normalizeBlogStats = (granularity: Granularity, rows: BlogStatPoint[]): NormalizedBlogStatPoint[] => {
+  const toNumber = (value: unknown) => {
+    if (typeof value === "number") return value;
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+
+  return rows.map((row, idx) => {
+    let label: string;
+    switch (granularity) {
+      case "daily":
+        label = row.statDate ?? `일자-${idx + 1}`;
+        break;
+      case "weekly":
+        if (row.startDate && row.endDate) {
+          label = `${row.startDate} ~ ${row.endDate}`;
+        } else if (row.week) {
+          label = row.week;
+        } else {
+          label = `주차-${idx + 1}`;
+        }
+        break;
+      default:
+        if (row.yearMonth) {
+          label = row.yearMonth;
+        } else if (row.startDate && row.endDate) {
+          label = `${row.startDate} ~ ${row.endDate}`;
+        } else {
+          label = `월-${idx + 1}`;
+        }
+        break;
+    }
+
+    // 증가율 계산 (전 기간 대비)
+    const postGrowthRate = idx > 0 && rows[idx - 1].postCount > 0
+      ? ((row.postCount - rows[idx - 1].postCount) / rows[idx - 1].postCount) * 100
+      : 0;
+
+    return {
+      label,
+      postCount: toNumber(row.postCount),
+      postGrowthRate,
+    };
+  });
+};

--- a/src/components/admin/types.ts
+++ b/src/components/admin/types.ts
@@ -1,6 +1,6 @@
 import { LucideIcon } from "lucide-react";
 
-export type AdminSection = "notice" | "user" | "code" | "workflow" | "work" | "stats";
+export type AdminSection = "notice" | "user" | "code" | "workflow" | "work" | "stats" | "blog";
 
 export type AdminNavItem = {
   id: AdminSection;
@@ -60,3 +60,18 @@ export type NormalizedUserStatPoint = {
 
 export type DailyRange = { start: string; end: string };
 export type WeeklyPeriod = { year: number; month: number };
+
+export type BlogStatPoint = {
+  statDate?: string;
+  week?: string;
+  startDate?: string;
+  endDate?: string;
+  yearMonth?: string;
+  postCount: number;
+};
+
+export type NormalizedBlogStatPoint = {
+  label: string;
+  postCount: number;
+  postGrowthRate: number;
+};

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -1,0 +1,140 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { AxiosError } from "axios";
+import { Granularity, DailyRange, WeeklyPeriod } from "@/components/admin/types";
+import { statisticsService } from "@/services/statisticsService";
+
+type StatPoint = {
+  label: string;
+  [key: string]: string | number;
+};
+
+type UseStatisticsParams<T> = {
+  active: boolean;
+  statType: "user" | "blog";
+  normalizeStats: (granularity: Granularity, raw: any[]) => T[];
+  defaultDailyRange: () => DailyRange;
+  defaultWeeklyPeriod: () => WeeklyPeriod;
+  defaultMonthlyYear: () => number;
+  errorMessage: string;
+};
+
+export function useStatistics<T extends StatPoint>({
+  active,
+  statType,
+  normalizeStats,
+  defaultDailyRange,
+  defaultWeeklyPeriod,
+  defaultMonthlyYear,
+  errorMessage,
+}: UseStatisticsParams<T>) {
+  const [granularity, setGranularity] = useState<Granularity>("daily");
+  const [dailyRange, setDailyRange] = useState<DailyRange>(defaultDailyRange());
+  const [weeklyPeriod, setWeeklyPeriod] = useState<WeeklyPeriod>(defaultWeeklyPeriod());
+  const [monthlyYear, setMonthlyYear] = useState<number>(defaultMonthlyYear());
+  const [data, setData] = useState<T[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isReaggregating, setIsReaggregating] = useState(false);
+
+  const fetchStats = useCallback(async () => {
+    try {
+      setLoading(true);
+      const getStatsMethod = statType === "user"
+        ? statisticsService.getUserStats
+        : statisticsService.getBlogStats;
+
+      const raw =
+        granularity === "daily"
+          ? await getStatsMethod({
+              granularity,
+              startDate: dailyRange.start,
+              endDate: dailyRange.end,
+            })
+          : granularity === "weekly"
+          ? await getStatsMethod({
+              granularity,
+              year: weeklyPeriod.year,
+              month: weeklyPeriod.month,
+            })
+          : await getStatsMethod({
+              granularity,
+              year: monthlyYear,
+            });
+      setData(normalizeStats(granularity, raw));
+      setError(null);
+    } catch (err) {
+      const msg = err instanceof AxiosError
+        ? err.response?.data?.message || err.message
+        : err instanceof Error
+        ? err.message
+        : errorMessage;
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    statType,
+    granularity,
+    dailyRange.start,
+    dailyRange.end,
+    weeklyPeriod.year,
+    weeklyPeriod.month,
+    monthlyYear,
+    normalizeStats,
+    errorMessage,
+  ]);
+
+  useEffect(() => {
+    if (!active) return;
+    fetchStats();
+  }, [active, fetchStats]);
+
+  const handleReaggregate = useCallback(async () => {
+    if (granularity !== "daily") {
+      alert("일별 조회 모드에서만 재집계가 가능합니다.");
+      return;
+    }
+
+    const confirmed = confirm(
+      `${dailyRange.start} ~ ${dailyRange.end} 기간의 통계를 재집계하시겠습니까?\n기존 데이터는 덮어씌워집니다.`
+    );
+
+    if (!confirmed) return;
+
+    try {
+      setIsReaggregating(true);
+      await statisticsService.reaggregateStats(dailyRange.start, dailyRange.end);
+
+      // 재집계 성공 후 통계 다시 불러오기
+      await fetchStats();
+
+      alert("통계 재집계가 완료되었습니다.");
+    } catch (err) {
+      const msg = err instanceof AxiosError
+        ? err.response?.data?.message || err.message
+        : "재집계에 실패했습니다.";
+      alert(msg);
+    } finally {
+      setIsReaggregating(false);
+    }
+  }, [granularity, dailyRange.start, dailyRange.end, fetchStats]);
+
+  const latest = useMemo(() => data[data.length - 1], [data]);
+
+  return {
+    granularity,
+    setGranularity,
+    dailyRange,
+    setDailyRange,
+    weeklyPeriod,
+    setWeeklyPeriod,
+    monthlyYear,
+    setMonthlyYear,
+    data,
+    loading,
+    error,
+    isReaggregating,
+    handleReaggregate,
+    latest,
+  };
+}

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { AxiosError } from "axios";
-import { Granularity, DailyRange, WeeklyPeriod } from "@/components/admin/types";
+import { Granularity, DailyRange, WeeklyPeriod, UserStatPoint, BlogStatPoint } from "@/components/admin/types";
 import { statisticsService } from "@/services/statisticsService";
 
 type StatPoint = {
@@ -8,17 +8,19 @@ type StatPoint = {
   [key: string]: string | number;
 };
 
-type UseStatisticsParams<T> = {
+type RawStatPoint = UserStatPoint | BlogStatPoint;
+
+type UseStatisticsParams<T extends StatPoint, R extends RawStatPoint> = {
   active: boolean;
   statType: "user" | "blog";
-  normalizeStats: (granularity: Granularity, raw: any[]) => T[];
+  normalizeStats: (granularity: Granularity, raw: R[]) => T[];
   defaultDailyRange: () => DailyRange;
   defaultWeeklyPeriod: () => WeeklyPeriod;
   defaultMonthlyYear: () => number;
   errorMessage: string;
 };
 
-export function useStatistics<T extends StatPoint>({
+export function useStatistics<T extends StatPoint, R extends RawStatPoint>({
   active,
   statType,
   normalizeStats,
@@ -26,7 +28,7 @@ export function useStatistics<T extends StatPoint>({
   defaultWeeklyPeriod,
   defaultMonthlyYear,
   errorMessage,
-}: UseStatisticsParams<T>) {
+}: UseStatisticsParams<T, R>) {
   const [granularity, setGranularity] = useState<Granularity>("daily");
   const [dailyRange, setDailyRange] = useState<DailyRange>(defaultDailyRange());
   const [weeklyPeriod, setWeeklyPeriod] = useState<WeeklyPeriod>(defaultWeeklyPeriod());
@@ -39,27 +41,44 @@ export function useStatistics<T extends StatPoint>({
   const fetchStats = useCallback(async () => {
     try {
       setLoading(true);
-      const getStatsMethod = statType === "user"
-        ? statisticsService.getUserStats
-        : statisticsService.getBlogStats;
+      let raw: R[];
 
-      const raw =
-        granularity === "daily"
-          ? await getStatsMethod({
+      if (statType === "user") {
+        raw = (granularity === "daily"
+          ? await statisticsService.getUserStats({
               granularity,
               startDate: dailyRange.start,
               endDate: dailyRange.end,
             })
           : granularity === "weekly"
-          ? await getStatsMethod({
+          ? await statisticsService.getUserStats({
               granularity,
               year: weeklyPeriod.year,
               month: weeklyPeriod.month,
             })
-          : await getStatsMethod({
+          : await statisticsService.getUserStats({
               granularity,
               year: monthlyYear,
-            });
+            })) as R[];
+      } else {
+        raw = (granularity === "daily"
+          ? await statisticsService.getBlogStats({
+              granularity,
+              startDate: dailyRange.start,
+              endDate: dailyRange.end,
+            })
+          : granularity === "weekly"
+          ? await statisticsService.getBlogStats({
+              granularity,
+              year: weeklyPeriod.year,
+              month: weeklyPeriod.month,
+            })
+          : await statisticsService.getBlogStats({
+              granularity,
+              year: monthlyYear,
+            })) as R[];
+      }
+
       setData(normalizeStats(granularity, raw));
       setError(null);
     } catch (err) {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { Header } from "@/components/common/Header";
+import { useSearchParams } from "react-router-dom";
+import { AdminHeader } from "@/components/admin/AdminHeader";
 import { AdminSidebar } from "@/components/admin/AdminSidebar";
 import { AdminMainContent } from "@/components/admin/AdminMainContent";
 import { AdminNavItem, AdminSection, UserFilterInfo, WorkflowFilterInfo } from "@/components/admin/types";
-import { ClipboardList, Settings2, Users, Workflow, FileText, BarChart3 } from "lucide-react";
+import { ClipboardList, Settings2, Users, Workflow, FileText, BarChart3, BookOpen } from "lucide-react";
 
 const adminNav: AdminNavItem[] = [
     { id: "notice", label: "공지사항 관리", description: "공지 등록/수정/삭제", icon: ClipboardList },
@@ -12,46 +13,43 @@ const adminNav: AdminNavItem[] = [
     { id: "work", label: "워크 관리", description: "전체 워크 조회/관리", icon: FileText },
     { id: "code", label: "공통 코드 관리", description: "카테고리 코드 관리", icon: Settings2 },
     { id: "stats", label: "사용자 통계", description: "가입/활성 사용자 추이", icon: BarChart3 },
+    { id: "blog", label: "블로그 통계", description: "포스트 발행 추이", icon: BookOpen },
 ];
 
 export default function AdminDashboard() {
-    const [section, setSection] = useState<AdminSection>("notice");
+    const [searchParams, setSearchParams] = useSearchParams();
     const [userFilter, setUserFilter] = useState<UserFilterInfo | undefined>(undefined);
     const [workflowFilter, setWorkflowFilter] = useState<WorkflowFilterInfo | undefined>(undefined);
 
+    // URL에서 탭 정보 읽기, 없으면 기본값 "notice"
+    const section = (searchParams.get("tab") as AdminSection) || "notice";
+
+    // 탭 변경 시 URL 업데이트
     const handleSectionChange = (newSection: AdminSection, newUserFilter?: UserFilterInfo, newWorkflowFilter?: WorkflowFilterInfo) => {
-        setSection(newSection);
+        setSearchParams({ tab: newSection });
         setUserFilter(newUserFilter);
         setWorkflowFilter(newWorkflowFilter);
     };
 
     return (
-        <div className="min-h-screen bg-background">
-            <Header />
-            <main className="pt-24 pb-12 px-4 sm:px-6 lg:px-10 xl:px-16">
-                <div className="mx-auto w-full max-w-[1600px] space-y-6">
-                    <div className="flex gap-4 lg:gap-6 xl:gap-8">
-                        <AdminSidebar items={adminNav} activeId={section} onSelect={(newSection) => {
-                            setSection(newSection);
-                            setUserFilter(undefined); // 메뉴 클릭 시 필터 초기화
-                            setWorkflowFilter(undefined); // 메뉴 클릭 시 워크플로우 필터 초기화
-                        }} />
+        <div className="min-h-screen bg-gray-50">
+            <AdminHeader />
+            <AdminSidebar items={adminNav} activeId={section} onSelect={(newSection) => {
+                setSearchParams({ tab: newSection });
+                setUserFilter(undefined);
+                setWorkflowFilter(undefined);
+            }} />
 
-                        <div className="flex-1 space-y-4">
-                            <div className="space-y-1">
-                                <p className="text-sm text-muted-foreground">관리자</p>
-                                <h1 className="text-2xl font-bold text-foreground">관리자 대시보드</h1>
-                            </div>
-                            <div className="min-h-[560px]">
-                                <AdminMainContent
-                                    section={section}
-                                    onSectionChange={handleSectionChange}
-                                    userFilter={userFilter}
-                                    workflowFilter={workflowFilter}
-                                />
-                            </div>
-                        </div>
-                    </div>
+            {/* 메인 콘텐츠 - 사이드바 너비만큼 왼쪽 마진 */}
+            <main className="ml-[200px] pt-14 min-h-screen">
+                <div className="p-8">
+                    <h1 className="text-2xl font-semibold text-gray-800 mb-6">관리자 대시보드</h1>
+                    <AdminMainContent
+                        section={section}
+                        onSectionChange={handleSectionChange}
+                        userFilter={userFilter}
+                        workflowFilter={workflowFilter}
+                    />
                 </div>
             </main>
         </div>

--- a/src/services/statisticsService.ts
+++ b/src/services/statisticsService.ts
@@ -1,5 +1,5 @@
 import api from "@/lib/api";
-import { Granularity, UserStatPoint } from "@/components/admin/types";
+import { Granularity, UserStatPoint, BlogStatPoint } from "@/components/admin/types";
 
 export const statisticsService = {
   async getUserStats(
@@ -18,5 +18,30 @@ export const statisticsService = {
 
     const res = await api.get(`/api/v1/admin/statistics/${granularity}/users`, { params: query });
     return (res.data?.data as UserStatPoint[]) ?? [];
+  },
+
+  async getBlogStats(
+    params:
+      | { granularity: "daily"; startDate: string; endDate: string }
+      | { granularity: "weekly"; year: number; month: number }
+      | { granularity: "monthly"; year: number }
+  ) {
+    const { granularity } = params;
+    const query =
+      granularity === "daily"
+        ? { startDate: params.startDate, endDate: params.endDate }
+        : granularity === "weekly"
+        ? { year: params.year, month: params.month }
+        : { year: params.year };
+
+    const res = await api.get(`/api/v1/admin/statistics/${granularity}/posts`, { params: query });
+    return (res.data?.data as BlogStatPoint[]) ?? [];
+  },
+
+  async reaggregateStats(startDate: string, endDate: string) {
+    const res = await api.post('/api/v1/admin/statistics/manual-aggregate-range', null, {
+      params: { startDate, endDate }
+    });
+    return res.data;
   },
 };


### PR DESCRIPTION
## 📁 관련 이슈
#32 


## 🔥 작업 내용
  - 블로그 통계 페이지 추가 (일별/주별/월별 조회)
  - 블로그 통계 차트, 테이블, 요약 컴포넌트 구현
  - 사용자/블로그 통계 수동 재집계 API 연동
  - 일별 조회 모드에서 재집계 버튼 추가
  - 재집계 후 자동 새로고침 기

## 🧪 테스트 결과
<img width="1660" height="764" alt="image" src="https://github.com/user-attachments/assets/a1063b82-6e21-40ad-94b0-9181b7394b69" />