### PR TITLE
refactor: 관리자 페이지 UI/UX 개선(#42)

### DIFF
--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@/components/ui/button";
+import { LogOut, X } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
+import logoImg from "@/assets/logo.png";
+
+export function AdminHeader() {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/');
+  };
+
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 bg-white border-b border-gray-200">
+      <div className="flex items-center justify-between h-14 px-6">
+        {/* 왼쪽: 로고 + 타이틀 */}
+        <div className="flex items-center gap-3">
+          <a href="/admin" className="flex items-center">
+            <img
+              src={logoImg}
+              alt="OCP 로고"
+              className="h-12 w-auto object-contain"
+            />
+          </a>
+          <span className="text-base font-medium text-gray-700">관리자 시스템</span>
+        </div>
+
+        {/* 오른쪽: 버튼들 */}
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleLogout}
+            className="h-8 text-sm"
+          >
+            <LogOut className="mr-1.5 h-3.5 w-3.5" />
+            로그아웃
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => navigate('/')}
+            className="h-8 text-sm"
+          >
+            <X className="mr-1.5 h-3.5 w-3.5" />
+            나가기
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -1,6 +1,7 @@
 import { AdminNavItem } from "./types";
 import { cn } from "@/lib/utils";
-import { ArrowRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
 
 type AdminSidebarProps = {
   items: AdminNavItem[];
@@ -9,45 +10,36 @@ type AdminSidebarProps = {
 };
 
 export function AdminSidebar({ items, activeId, onSelect }: AdminSidebarProps) {
-  return (
-    <aside
-      className={cn(
-        "transition-all duration-200 ease-in-out",
-        "bg-card border border-border card-shadow rounded-xl",
-        "relative overflow-hidden w-[280px]",
-      )}
-    >
-      <div className="p-4">
-        <div className="mb-3">
-          <p className="text-sm font-semibold text-foreground">관리 항목</p>
-          <p className="text-xs text-muted-foreground">메뉴를 선택하면 오른쪽 콘텐츠가 전환됩니다.</p>
-        </div>
+  const { user } = useAuth();
 
-        <div className="flex flex-col gap-2">
-          {items.map((item) => {
-            const Icon = item.icon;
-            return (
-              <button
-                key={item.id}
-                onClick={() => onSelect(item.id)}
-                className={cn(
-                  "flex w-full items-center gap-3 rounded-lg border px-3 py-3 text-left transition-colors",
-                  activeId === item.id
-                    ? "border-primary bg-primary/5 text-primary"
-                    : "border-border hover:border-primary/50 hover:bg-muted/40",
-                )}
-              >
-                <Icon className="h-4 w-4 shrink-0" />
-                <div className="flex-1">
-                  <p className="font-semibold leading-tight">{item.label}</p>
-                  <p className="text-[11px] text-muted-foreground">{item.description}</p>
-                </div>
-                <ArrowRight className="h-4 w-4 shrink-0" />
-              </button>
-            );
-          })}
+  return (
+    <aside className="fixed left-0 top-14 bottom-0 w-[200px] bg-gray-50 border-r border-gray-200 overflow-y-auto">
+      {/* 사용자 정보 */}
+      {user && (
+        <div className="p-4 mb-2 bg-white border-b border-gray-200">
+          <p className="text-sm font-semibold text-gray-800">{user.name}</p>
+          <p className="text-xs text-gray-500 truncate">{user.email}</p>
         </div>
-      </div>
+      )}
+
+      {/* 메뉴 목록 */}
+      <nav className="px-3 py-2">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            onClick={() => onSelect(item.id)}
+            className={cn(
+              "flex w-full items-center justify-between px-3 py-2.5 mb-1 text-left text-sm transition-colors rounded",
+              activeId === item.id
+                ? "bg-blue-50 text-blue-600 font-medium"
+                : "text-gray-700 hover:bg-gray-100",
+            )}
+          >
+            <span>{item.label}</span>
+            <ChevronRight className="h-4 w-4 text-gray-400" />
+          </button>
+        ))}
+      </nav>
     </aside>
   );
 }

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Menu, X, LogOut, User } from "lucide-react";
+import { Menu, X, LogOut, User, ShieldCheck } from "lucide-react";
 import { NavLink } from "@/components/NavLink";
 import { useAuth } from "@/contexts/AuthContext";
 import { useNavigate } from "react-router-dom";
@@ -126,6 +126,12 @@ export function Header({ onLoginClick }: HeaderProps) {
                   <User className="mr-2 h-4 w-4" />
                   마이페이지
                 </DropdownMenuItem>
+                {user.role === 'ADMIN' && (
+                  <DropdownMenuItem onClick={() => navigate('/admin')}>
+                    <ShieldCheck className="mr-2 h-4 w-4" />
+                    관리자 페이지
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleLogout} className="text-destructive focus:text-destructive">
                   <LogOut className="mr-2 h-4 w-4" />
@@ -225,6 +231,19 @@ export function Header({ onLoginClick }: HeaderProps) {
                   <User className="mr-2 h-4 w-4" />
                   마이페이지
                 </Button>
+                {user?.role === 'ADMIN' && (
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      navigate('/admin');
+                      setIsMenuOpen(false);
+                    }}
+                    className="justify-start"
+                  >
+                    <ShieldCheck className="mr-2 h-4 w-4" />
+                    관리자 페이지
+                  </Button>
+                )}
                 <Button
                   variant="outline"
                   onClick={handleLogout}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -6,6 +6,7 @@ export interface User {
   name: string;
   provider: string;
   picture?: string;
+  role?: string;
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
## 📁 관련 이슈
#42 

## 🔥 작업 내용
  - AdminHeader 재설계: OCP 로고 + 로그아웃/나가기 버튼
  - AdminSidebar 재설계: 사용자 정보 박스 + 심플한 메뉴
  - User 타입에 role 필드 추가
  - 일반 Header에 관리자 페이지 링크 추가 (관리자 권한만)

## 🧪 테스트 결과
<img width="1912" height="758" alt="image" src="https://github.com/user-attachments/assets/aeb06304-1ead-4fa3-8408-b13ba8dabc08" />