### PR TITLE
feat: 관리자 통계 테이블 페이징 구현(#43)

### DIFF
--- a/src/components/admin/AdminBlogStatsTable.tsx
+++ b/src/components/admin/AdminBlogStatsTable.tsx
@@ -1,5 +1,8 @@
+import { useState, useMemo } from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { NormalizedBlogStatPoint } from "./types";
 import { formatRate } from "./blogStatsUtils";
 
@@ -7,31 +10,84 @@ type Props = {
   data: NormalizedBlogStatPoint[];
 };
 
+const ITEMS_PER_PAGE = 10;
+
 export function AdminBlogStatsTable({ data }: Props) {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(data.length / ITEMS_PER_PAGE);
+
+  const paginatedData = useMemo(() => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+    return data.slice(startIndex, endIndex);
+  }, [data, currentPage]);
+
+  const handlePrevPage = () => {
+    setCurrentPage((prev) => Math.max(1, prev - 1));
+  };
+
+  const handleNextPage = () => {
+    setCurrentPage((prev) => Math.min(totalPages, prev + 1));
+  };
+
   return (
-    <div className="rounded-lg border border-border overflow-hidden">
-      <Table>
-        <TableHeader>
-          <TableRow className="bg-secondary/50">
-            <TableHead className="w-48 text-center">기간</TableHead>
-            <TableHead className="w-32 text-center">포스트 수</TableHead>
-            <TableHead className="w-32 text-center">전 기간 대비</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data.map((row) => (
-            <TableRow key={row.label} className="hover:bg-muted/50">
-              <TableCell className="text-center text-muted-foreground">{row.label}</TableCell>
-              <TableCell className="text-center font-semibold text-foreground">{row.postCount.toLocaleString()}</TableCell>
-              <TableCell className="text-center">
-                <Badge variant={row.postGrowthRate >= 0 ? "success" : "destructive"} className="min-w-[80px] justify-center">
-                  {formatRate(row.postGrowthRate)}
-                </Badge>
-              </TableCell>
+    <div className="space-y-3">
+      <div className="rounded-lg border border-border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-secondary/50">
+              <TableHead className="w-48 text-center">기간</TableHead>
+              <TableHead className="w-32 text-center">포스트 수</TableHead>
+              <TableHead className="w-32 text-center">전 기간 대비</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {paginatedData.map((row) => (
+              <TableRow key={row.label} className="hover:bg-muted/50">
+                <TableCell className="text-center text-muted-foreground">{row.label}</TableCell>
+                <TableCell className="text-center font-semibold text-foreground">{row.postCount.toLocaleString()}</TableCell>
+                <TableCell className="text-center">
+                  <Badge variant={row.postGrowthRate >= 0 ? "success" : "destructive"} className="min-w-[80px] justify-center">
+                    {formatRate(row.postGrowthRate)}
+                  </Badge>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-2">
+          <p className="text-sm text-muted-foreground">
+            총 {data.length}개 중 {((currentPage - 1) * ITEMS_PER_PAGE) + 1}-{Math.min(currentPage * ITEMS_PER_PAGE, data.length)}개 표시
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handlePrevPage}
+              disabled={currentPage === 1}
+              className="h-8 w-8 p-0"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm font-medium">
+              {currentPage} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleNextPage}
+              disabled={currentPage === totalPages}
+              className="h-8 w-8 p-0"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/admin/AdminUserStatsTable.tsx
+++ b/src/components/admin/AdminUserStatsTable.tsx
@@ -1,5 +1,8 @@
+import { useState, useMemo } from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { NormalizedUserStatPoint } from "./types";
 import { formatRate } from "./userStatsUtils";
 
@@ -7,39 +10,92 @@ type Props = {
   data: NormalizedUserStatPoint[];
 };
 
+const ITEMS_PER_PAGE = 10;
+
 export function AdminUserStatsTable({ data }: Props) {
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.ceil(data.length / ITEMS_PER_PAGE);
+
+  const paginatedData = useMemo(() => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+    return data.slice(startIndex, endIndex);
+  }, [data, currentPage]);
+
+  const handlePrevPage = () => {
+    setCurrentPage((prev) => Math.max(1, prev - 1));
+  };
+
+  const handleNextPage = () => {
+    setCurrentPage((prev) => Math.min(totalPages, prev + 1));
+  };
+
   return (
-    <div className="rounded-lg border border-border overflow-hidden">
-      <Table>
-        <TableHeader>
-          <TableRow className="bg-secondary/50">
-            <TableHead className="w-32 text-center">기간</TableHead>
-            <TableHead className="w-32 text-center">총 사용자</TableHead>
-            <TableHead className="w-32 text-center">전일 대비</TableHead>
-            <TableHead className="w-32 text-center">활성 사용자</TableHead>
-            <TableHead className="w-32 text-center">전일 대비</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {data.map((row) => (
-            <TableRow key={row.label} className="hover:bg-muted/50">
-              <TableCell className="text-center text-muted-foreground">{row.label}</TableCell>
-              <TableCell className="text-center font-semibold text-foreground">{row.totalUsers.toLocaleString()}</TableCell>
-              <TableCell className="text-center">
-                <Badge variant={row.userGrowthRate >= 0 ? "success" : "destructive"} className="min-w-[80px] justify-center">
-                  {formatRate(row.userGrowthRate)}
-                </Badge>
-              </TableCell>
-              <TableCell className="text-center font-semibold text-foreground">{row.activeUsers.toLocaleString()}</TableCell>
-              <TableCell className="text-center">
-                <Badge variant={row.activeUserGrowthRate >= 0 ? "success" : "destructive"} className="min-w-[80px] justify-center">
-                  {formatRate(row.activeUserGrowthRate)}
-                </Badge>
-              </TableCell>
+    <div className="space-y-3">
+      <div className="rounded-lg border border-border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-secondary/50">
+              <TableHead className="w-32 text-center">기간</TableHead>
+              <TableHead className="w-32 text-center">총 사용자</TableHead>
+              <TableHead className="w-32 text-center">전일 대비</TableHead>
+              <TableHead className="w-32 text-center">활성 사용자</TableHead>
+              <TableHead className="w-32 text-center">전일 대비</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {paginatedData.map((row) => (
+              <TableRow key={row.label} className="hover:bg-muted/50">
+                <TableCell className="text-center text-muted-foreground">{row.label}</TableCell>
+                <TableCell className="text-center font-semibold text-foreground">{row.totalUsers.toLocaleString()}</TableCell>
+                <TableCell className="text-center">
+                  <Badge variant={row.userGrowthRate >= 0 ? "success" : "destructive"} className="min-w-[80px] justify-center">
+                    {formatRate(row.userGrowthRate)}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-center font-semibold text-foreground">{row.activeUsers.toLocaleString()}</TableCell>
+                <TableCell className="text-center">
+                  <Badge variant={row.activeUserGrowthRate >= 0 ? "success" : "destructive"} className="min-w-[80px] justify-center">
+                    {formatRate(row.activeUserGrowthRate)}
+                  </Badge>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-2">
+          <p className="text-sm text-muted-foreground">
+            총 {data.length}개 중 {((currentPage - 1) * ITEMS_PER_PAGE) + 1}-{Math.min(currentPage * ITEMS_PER_PAGE, data.length)}개 표시
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handlePrevPage}
+              disabled={currentPage === 1}
+              className="h-8 w-8 p-0"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm font-medium">
+              {currentPage} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleNextPage}
+              disabled={currentPage === totalPages}
+              className="h-8 w-8 p-0"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📁 관련 이슈
#43 

## 🔥 작업 내용
  - 사용자 통계 테이블 페이징 추가 (10개씩)
  - 블로그 통계 테이블 페이징 추가 (10개씩)
  - 이전/다음 버튼 및 페이지 정보 표시
  - 데이터 10개 이하 시 페이징 UI 자동 숨김

## 🧪 테스트 결과
<img width="1614" height="674" alt="image" src="https://github.com/user-attachments/assets/caf4c864-cc0a-4799-8046-5f27b1928a62" />